### PR TITLE
Added PacletInfo.m

### DIFF
--- a/WebUnit/PacletInfo.m
+++ b/WebUnit/PacletInfo.m
@@ -1,0 +1,11 @@
+(* Paclet Info File *)
+
+(* created 2016.10.27*)
+
+Paclet[
+  Name -> "WebUnit",
+  Version -> "0.0.1",
+  MathematicaVersion -> "6+",
+  Extensions -> {
+    {"Documentation", Language -> "English"}
+}]


### PR DESCRIPTION
Adding PacletInfo.m will enable the documentation build for this application in Eclipse. This will make the documentation available in the Wolfram Documentation Center once the application is installed.
